### PR TITLE
28 panel create resource #28

### DIFF
--- a/arches_arcgispro_addin/Config.daml
+++ b/arches_arcgispro_addin/Config.daml
@@ -63,7 +63,7 @@
         </button-->
       </controls>
       <dockPanes>
-        <dockPane id="arches_arcgispro_addin_MainDockpane" caption="Arhces Connection" className="MainDockpaneViewModel" dock="group" dockWith="esri_core_contentsDockPane">
+        <dockPane id="arches_arcgispro_addin_MainDockpane" caption="Arches Connection" className="MainDockpaneViewModel" dock="group" dockWith="esri_core_contentsDockPane">
           <content className="MainDockpaneView" />
         </dockPane>
         <dockPane id="arches_arcgispro_addin_SaveResource" caption="Save Resource" className="SaveResourceViewModel" dock="group" dockWith="esri_core_contentsDockPane">

--- a/arches_arcgispro_addin/CreateResource.xaml
+++ b/arches_arcgispro_addin/CreateResource.xaml
@@ -35,18 +35,17 @@
             Text="1. To Start creating, select a Geometry Node from the resource model to create a new resource instance click the Select button"/>
         <TextBlock HorizontalAlignment="Left" Margin="50,100,0,0" Grid.Row="1" Text="Available Geometry Nodes" VerticalAlignment="Top"/>
         <ComboBox HorizontalAlignment="Left" Margin="50,120,0,0" Grid.Row="1" VerticalAlignment="Top" Width="210"/>
-        <Button Content="Select Geometry Node" HorizontalAlignment="Center" Margin="0,160,0,0" Grid.Row="1" VerticalAlignment="Top" Width="150" Click="Button_Click" />
 
-        <TextBlock HorizontalAlignment="Left" Margin="50,210,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
+        <TextBlock HorizontalAlignment="Left" Margin="50,160,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
             Text="2. Select a geometry and click the Submit button to create Arches geometry" />
-        <Button Content="Submit to Arches" HorizontalAlignment="Center" Margin="0,270,0,0" Grid.Row="1" VerticalAlignment="Top" Width="150" Click="Button_Click_1" />
+        <Button Content="Submit to Arches" HorizontalAlignment="Center" Margin="0,220,0,0" Grid.Row="1" VerticalAlignment="Top" Width="150" Click="Button_Click" />
         
-        <TextBlock HorizontalAlignment="Left" Margin="50,310,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
+        <TextBlock HorizontalAlignment="Left" Margin="50,250,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
             Text="3. Continue editing attributes using Arches Resource Editor" />
-        <TextBlock HorizontalAlignment="Left" FontWeight="bold"  Margin="50,350,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
+        <TextBlock HorizontalAlignment="Left" FontWeight="bold"  Margin="50,290,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
                    Text="Resouce Instance ID being edited: " />
-        <TextBlock HorizontalAlignment="Left" FontWeight="bold"  Margin="50,370,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
+        <TextBlock HorizontalAlignment="Left" FontWeight="bold"  Margin="50,310,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
                    Text="{Binding ResourceIDEdited}" />
-        <Button Content="Edit using Arches Resource Editor" HorizontalAlignment="Center" Margin="0,400,0,0" Grid.Row="1" VerticalAlignment="Top" Width="180" Click="Button_Click_2" />
+        <Button Content="Edit using Arches Resource Editor" HorizontalAlignment="Center" Margin="0,340,0,0" Grid.Row="1" VerticalAlignment="Top" Width="180" Click="Button_Click_1" />
     </Grid>
 </UserControl>

--- a/arches_arcgispro_addin/CreateResource.xaml.cs
+++ b/arches_arcgispro_addin/CreateResource.xaml.cs
@@ -1,8 +1,14 @@
-﻿using System;
+﻿using ArcGIS.Core.Geometry;
+using ArcGIS.Desktop.Editing.Attributes;
+using ArcGIS.Desktop.Framework.Threading.Tasks;
+using ArcGIS.Desktop.Mapping;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web.Script.Serialization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -26,18 +32,58 @@ namespace arches_arcgispro_addin
             InitializeComponent();
         }
 
-        private void Button_Click(object sender, RoutedEventArgs e)
+        private async void Button_Click(object sender, RoutedEventArgs e)
         {
+            try
+            {
+                if (MapView.Active == null)
+                {
+                    ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("No MapView currently active. Exiting...", "Info");
+                    return;
+                }
+                if (StaticVariables.myInstanceURL == "" | StaticVariables.myInstanceURL == null)
+                {
+                    ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Log in to Arches Server...");
+                    return;
+                }
+                if (StaticVariables.archesNodeid == "" | StaticVariables.archesNodeid == null)
+                {
+                    ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Select a Geometry Node to use...");
+                    return;
+                }
+                if (StaticVariables.archesResourceid != "" && StaticVariables.archesResourceid != null)
+                {
+                    StaticVariables.archesResourceid = "";
+                }
 
+                string archesGeometryString = await SaveResourceView.GetGeometryString();
+                string archesData = "data";
+                var result = await SaveResourceView.SubmitToArches("", StaticVariables.archesNodeid, archesData, archesGeometryString);
+                StaticVariables.archesResourceid = result["results"];
+                ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show($"A resource id: \n{StaticVariables.archesResourceid} is assigned");
+                SaveResourceView.RefreshMapView();
+            }
+            catch (Exception ex)
+            {
+                ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Exception: " + ex.Message);
+            }
         }
 
         private void Button_Click_1(object sender, RoutedEventArgs e)
         {
-
-        }
-
-        private void Button_Click_2(object sender, RoutedEventArgs e)
-        {
+            if (StaticVariables.myInstanceURL == "" | StaticVariables.myInstanceURL == null)
+            {
+                ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Log in to Arches Server...");
+                return;
+            }
+            if (StaticVariables.archesResourceid == "" | StaticVariables.archesResourceid == null)
+            {
+                ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Submit a Geometry to Arches to Create a Resource...");
+                return;
+            }
+            string editorAddress = StaticVariables.myInstanceURL + $"resource/{StaticVariables.archesResourceid}";
+            ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("opening... \n" + editorAddress);
+            System.Diagnostics.Process.Start(editorAddress);
 
         }
     }

--- a/arches_arcgispro_addin/SaveResource.xaml.cs
+++ b/arches_arcgispro_addin/SaveResource.xaml.cs
@@ -24,7 +24,7 @@ using System.Windows.Shapes;
 namespace arches_arcgispro_addin
 {
     /// <summary>
-    /// Interaction logic for Dockpane1View.xaml
+    /// Interaction logic for SaveResourceView.xaml
     /// </summary>
     public partial class SaveResourceView : UserControl
     {
@@ -56,7 +56,7 @@ namespace arches_arcgispro_addin
             });
         }
 
-        private ArcGIS.Core.Geometry.Geometry SRTransform(ArcGIS.Core.Geometry.Geometry inGeometry, int inSRID, int outSRID)
+        private static ArcGIS.Core.Geometry.Geometry SRTransform(ArcGIS.Core.Geometry.Geometry inGeometry, int inSRID, int outSRID)
         {
             ArcGIS.Core.Geometry.Geometry outGeometry;
             SpatialReference inSR = SpatialReferenceBuilder.CreateSpatialReference(inSRID);
@@ -66,7 +66,7 @@ namespace arches_arcgispro_addin
             return outGeometry;
         }
 
-        private async Task<string> GetGeometryString()
+        public static async Task<string> GetGeometryString()
         {
             ArcGIS.Core.Geometry.Geometry archesGeometry;
             string archesGeometryString;
@@ -105,7 +105,7 @@ namespace arches_arcgispro_addin
             return args;
         }
 
-        private async Task<Dictionary<string, string>> SubmitToArches(string tileid, string nodeid, string data, string geojson)
+        public static async Task<Dictionary<string, string>> SubmitToArches(string tileid, string nodeid, string data, string geojson)
         {
             Dictionary<String, String> result = new Dictionary<String, String>();
 
@@ -134,7 +134,7 @@ namespace arches_arcgispro_addin
             return result;
         }
 
-        private async void RefreshMapView()
+        public static async void RefreshMapView()
         {
             await QueuedTask.Run(() =>
             {
@@ -142,7 +142,7 @@ namespace arches_arcgispro_addin
             });
         }
 
-            private void Button_Click(object sender, RoutedEventArgs e)
+        private void Button_Click(object sender, RoutedEventArgs e)
         {
             // Check for an active mapview
             try


### PR DESCRIPTION
Add a logic behind the create resource. #28 

The assumption is if a geometry is submitted to Arches without a resource instance id, Arches will assign a resource instance id and save it to a tile and return a resource instance id back as a response. Then ArcGIS Pro will save the resource instance id and use it to create an address for editor.