### PR TITLE
Deactivating buttons to open dockpanes, re #56

### DIFF
--- a/arches_arcgispro_addin/Config.daml
+++ b/arches_arcgispro_addin/Config.daml
@@ -63,10 +63,10 @@
         <dockPane id="arches_arcgispro_addin_MainDockpane" caption="Arches Connection" className="MainDockpaneViewModel" dock="group" dockWith="esri_core_contentsDockPane">
           <content className="MainDockpaneView" />
         </dockPane>
-        <dockPane id="arches_arcgispro_addin_SaveResource" caption="Save Resource" className="SaveResourceViewModel" dock="group" dockWith="esri_core_contentsDockPane" condition = "token_condition">
+        <dockPane id="arches_arcgispro_addin_SaveResource" caption="Save Resource" className="SaveResourceViewModel" dock="group" dockWith="esri_core_contentsDockPane">
           <content className="SaveResourceView" />
         </dockPane>
-        <dockPane id="arches_arcgispro_addin_CreateResource" caption="Create Resource" className="CreateResourceViewModel" dock="group" dockWith="esri_core_contentsDockPane" condition = "token_condition">
+        <dockPane id="arches_arcgispro_addin_CreateResource" caption="Create Resource" className="CreateResourceViewModel" dock="group" dockWith="esri_core_contentsDockPane">
           <content className="CreateResourceView" />
         </dockPane>
       </dockPanes>

--- a/arches_arcgispro_addin/Config.daml
+++ b/arches_arcgispro_addin/Config.daml
@@ -11,7 +11,7 @@
                     Content, Framework, Editing, Geodatabase, Geometry, Geoprocessing, Layouts, Map Authoring, Map Exploration -->
   </AddInInfo>
   <modules>
-    <insertModule id="arches_arcgispro_addin_Module" className="Module1" autoLoad="false" caption="Module1">
+    <insertModule id="arches_arcgispro_addin_Module" className="Module1" autoLoad="true" caption="Module1">
       <!-- uncomment to have the control hosted on a separate tab-->
       <tabs>
         <tab id="arches_arcgispro_addin_Tab1" caption="Arches Project">
@@ -21,16 +21,10 @@
         </tab>
       </tabs>
       <groups>
-        <!-- comment this out if you have no controls on the Addin tab to avoid
-              an empty group-->
         <group id="arches_arcgispro_addin_Group1" caption="Arches Project Tools" appearsOnAddInTab="false">
-          <!-- host controls within groups -->
-          <!--button refID="arches_arcgispro_addin_Login" size="large" /-->
           <button refID="arches_arcgispro_addin_MainDockpane_ShowButton" size="large" />
           <button refID="arches_arcgispro_addin_SaveResource_ShowButton" size="large" />
           <button refID="arches_arcgispro_addin_CreateResource_ShowButton" size="large" />
-          <!--button refID="arches_arcgispro_addin_ResourceModelDockpane_ShowButton" size="large" />
-          <button refID="arches_arcgispro_addin_AttributeTable_ShowButton" size="large" /-->
         </group>
         <group id="arches_arcgispro_addin_Group2" caption="ArcGIS Pro Tools" appearsOnAddInTab="false">
           <button refID="esri_mapping_addDataGallery" size="large" />
@@ -43,49 +37,38 @@
           <button refID="arches_arcgispro_addin_UI_ChromePane_OpenButton" size="large" />
         </group>
       </groups>
+
+      <conditions>
+        <insertCondition id="token_condition" caption="token state">
+          <state id="token_state" />
+        </insertCondition>
+      </conditions>
+      
       <controls>
-        <!-- add your controls here -->
-        <!--button id="arches_arcgispro_addin_Login" caption="Test" className="Login" loadOnClick="true" largeImage="Images\Stormtrooper32.png" smallImage="Images\Stormtrooper16.png">
-          <tooltip heading="Tooltip Heading">Tooltip text<disabledText /></tooltip>
-        </button-->
         <button id="arches_arcgispro_addin_MainDockpane_ShowButton" caption="Arches Connection" className="MainDockpane_ShowButton" loadOnClick="true" largeImage="Images\ArchesIcon32.png" smallImage="Images\ArchesIcon16.png">
           <tooltip heading="Arches Instance">Connect to Arches Instance<disabledText /></tooltip>
         </button>
-        <button id="arches_arcgispro_addin_SaveResource_ShowButton" caption="Save Resource" className="SaveResource_ShowButton" loadOnClick="true" largeImage="Images\AddinDesktop32.png" smallImage="Images\AddinDesktop16.png">
+        <button id="arches_arcgispro_addin_SaveResource_ShowButton" caption="Save Resource" className="SaveResource_ShowButton" loadOnClick="true" largeImage="Images\AddinDesktop32.png" smallImage="Images\AddinDesktop16.png" condition = "token_condition">
           <tooltip heading="Save Resources">Save Geometry to the selected reousrce instance<disabledText />
           </tooltip>
         </button>
-        <button id="arches_arcgispro_addin_CreateResource_ShowButton" caption="Create Resource" className="CreateResource_ShowButton" loadOnClick="true" smallImage="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/GenericButtonPurple16.png" largeImage="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/GenericButtonPurple32.png">
+        <button id="arches_arcgispro_addin_CreateResource_ShowButton" caption="Create Resource" className="CreateResource_ShowButton" loadOnClick="true" smallImage="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/GenericButtonPurple16.png" largeImage="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/GenericButtonPurple32.png" condition = "token_condition">
           <tooltip heading="Show Dockpane">Create a New Resource<disabledText /></tooltip>
         </button>
         <button id="arches_arcgispro_addin_UI_ChromePane_OpenButton" caption="Open Chromium Pane" className="arches_arcgispro_addin.UI.ChromePane_OpenButton" loadOnClick="true" smallImage="Images\chromium16.png" largeImage="Images\chromium32.png">
           <tooltip heading="Open Chromium Pane">Open Chromium Pane<disabledText /></tooltip>
         </button>
-        
-        <!--button id="arches_arcgispro_addin_ResourceModelDockpane_ShowButton" caption="Import Resource" className="ResourceModelDockpane_ShowButton" loadOnClick="true" smallImage="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/GenericButtonPurple16.png" largeImage="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/GenericButtonPurple32.png">
-          <tooltip heading="Import Resources">Import resources from the selected resource model<disabledText /></tooltip>
-        </button>
-        <button id="arches_arcgispro_addin_AttributeTable_ShowButton" caption="Show AttributeTable" className="AttributeTable_ShowButton" loadOnClick="true" smallImage="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/GenericButtonPurple16.png" largeImage="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/GenericButtonPurple32.png">
-          <tooltip heading="Show Attributes">Show Attributes<disabledText />
-          </tooltip>
-        </button-->
       </controls>
       <dockPanes>
         <dockPane id="arches_arcgispro_addin_MainDockpane" caption="Arches Connection" className="MainDockpaneViewModel" dock="group" dockWith="esri_core_contentsDockPane">
           <content className="MainDockpaneView" />
         </dockPane>
-        <dockPane id="arches_arcgispro_addin_SaveResource" caption="Save Resource" className="SaveResourceViewModel" dock="group" dockWith="esri_core_contentsDockPane">
+        <dockPane id="arches_arcgispro_addin_SaveResource" caption="Save Resource" className="SaveResourceViewModel" dock="group" dockWith="esri_core_contentsDockPane" condition = "token_condition">
           <content className="SaveResourceView" />
         </dockPane>
-        <dockPane id="arches_arcgispro_addin_CreateResource" caption="Create Resource" className="CreateResourceViewModel" dock="group" dockWith="esri_core_contentsDockPane">
+        <dockPane id="arches_arcgispro_addin_CreateResource" caption="Create Resource" className="CreateResourceViewModel" dock="group" dockWith="esri_core_contentsDockPane" condition = "token_condition">
           <content className="CreateResourceView" />
         </dockPane>
-        <!--dockPane id="arches_arcgispro_addin_ResourceModelDockpane" caption="ResourceModelDockpane" className="ResourceModelDockpaneViewModel" dock="group" dockWith="esri_core_contentsDockPane">
-          <content className="ResourceModelDockpaneView" />
-        </dockPane>
-        <dockPane id="arches_arcgispro_addin_AttributeTable" caption="AttributeTable" className="AttributeTableViewModel" dock="group" dockWith="esri_core_contentsDockPane">
-          <content className="AttributeTableView" />
-        </dockPane-->
       </dockPanes>
       <panes>
         <pane id="arches_arcgispro_addin_UI_ChromePane" caption="ChromePane" className="arches_arcgispro_addin.UI.ChromePaneViewModel" smallImage="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/GenericButtonGreen16.png" defaultTab="esri_mapping_homeTab" defaultTool="esri_mapping_navigateTool">

--- a/arches_arcgispro_addin/CreateResource.xaml.cs
+++ b/arches_arcgispro_addin/CreateResource.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using ArcGIS.Core.Geometry;
 using ArcGIS.Desktop.Editing.Attributes;
+using ArcGIS.Desktop.Framework;
+using ArcGIS.Desktop.Framework.Contracts;
 using ArcGIS.Desktop.Framework.Threading.Tasks;
 using ArcGIS.Desktop.Mapping;
 using System;
@@ -73,6 +75,11 @@ namespace arches_arcgispro_addin
                 if (StaticVariables.myInstanceURL == "" | StaticVariables.myInstanceURL == null)
                 {
                     ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Log in to Arches Server...");
+
+                    DockPane pane = FrameworkApplication.DockPaneManager.Find("arches_arcgispro_addin_MainDockpane");
+                    if (pane == null)
+                        return;
+                    pane.Activate();
                     return;
                 }
                 StaticVariables.geometryNodes = await GetGeometryNode();
@@ -97,6 +104,11 @@ namespace arches_arcgispro_addin
                 if (StaticVariables.myInstanceURL == "" | StaticVariables.myInstanceURL == null)
                 {
                     ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Log in to Arches Server...");
+
+                    DockPane pane = FrameworkApplication.DockPaneManager.Find("arches_arcgispro_addin_MainDockpane");
+                    if (pane == null)
+                        return;
+                    pane.Activate();
                     return;
                 }
                 if (StaticVariables.archesNodeid == "" | StaticVariables.archesNodeid == null)
@@ -128,6 +140,11 @@ namespace arches_arcgispro_addin
             if (StaticVariables.myInstanceURL == "" | StaticVariables.myInstanceURL == null)
             {
                 ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Log in to Arches Server...");
+
+                DockPane pane = FrameworkApplication.DockPaneManager.Find("arches_arcgispro_addin_MainDockpane");
+                if (pane == null)
+                    return;
+                pane.Activate();
                 return;
             }
             if (StaticVariables.archesResourceid == "" | StaticVariables.archesResourceid == null)

--- a/arches_arcgispro_addin/MainDockpane.xaml.cs
+++ b/arches_arcgispro_addin/MainDockpane.xaml.cs
@@ -190,6 +190,7 @@ namespace arches_arcgispro_addin
                 StaticVariables.myPassword = Password.Password;
                 StaticVariables.myClientid = await GetClientId();
                 StaticVariables.myToken = await GetToken(StaticVariables.myClientid);
+                FrameworkApplication.State.Activate("token_state");
 
                 ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show($"Successfully Logged in to {StaticVariables.myInstanceURL}");
 
@@ -210,6 +211,8 @@ namespace arches_arcgispro_addin
             InstanceURL.Text = "";
             Username.Text = "";
             Password.Password = "";
+
+            FrameworkApplication.State.Deactivate("token_state");
         }
 
         private void Button_Click_2(object sender, RoutedEventArgs e)

--- a/arches_arcgispro_addin/SaveResource.xaml
+++ b/arches_arcgispro_addin/SaveResource.xaml
@@ -37,7 +37,7 @@
                   ItemsSource="{Binding FeatureLayers}" DisplayMemberPath="Name" 
                   SelectedItem="{Binding SelectedFeatureLayer}" /-->
 
-        <Button Content="Get Arches Parameters" HorizontalAlignment="Center" Margin="0,80,0,0" Grid.Row="1" VerticalAlignment="Top" Width="180" Click="Button_Click"/>
+        <Button Content="Register Arches Instance to Edit" HorizontalAlignment="Center" Margin="0,80,0,0" Grid.Row="1" VerticalAlignment="Top" Width="180" Click="Button_Click"/>
         <TextBlock HorizontalAlignment="Left" Margin="50,120,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
             Text="If you want to unregister the resource being edited click the Unregister"/>
         <Button Content="Unregister Arches Instance" HorizontalAlignment="Center" Margin="0,170,0,0" Grid.Row="1" VerticalAlignment="Top" Width="180" Click="Button_Click_1" />

--- a/arches_arcgispro_addin/SaveResource.xaml.cs
+++ b/arches_arcgispro_addin/SaveResource.xaml.cs
@@ -21,6 +21,7 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using ArcGIS.Desktop.Framework.Contracts;
 using System.Net.Http.Headers;
+using ArcGIS.Desktop.Framework;
 
 namespace arches_arcgispro_addin
 {
@@ -215,6 +216,11 @@ namespace arches_arcgispro_addin
                 if (StaticVariables.myInstanceURL == "" | StaticVariables.myInstanceURL == null)
                 {
                     ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Log in to Arches Server...");
+
+                    DockPane pane = FrameworkApplication.DockPaneManager.Find("arches_arcgispro_addin_MainDockpane");
+                    if (pane == null)
+                        return;
+                    pane.Activate();
                     return;
                 }
                 if (StaticVariables.archesResourceid == "" | StaticVariables.archesResourceid == null)
@@ -242,6 +248,11 @@ namespace arches_arcgispro_addin
             if (StaticVariables.myInstanceURL == "" | StaticVariables.myInstanceURL == null)
             {
                 ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Log in to Arches Server...");
+
+                DockPane pane = FrameworkApplication.DockPaneManager.Find("arches_arcgispro_addin_MainDockpane");
+                if (pane == null)
+                    return;
+                pane.Activate();
                 return;
             }
             if (StaticVariables.archesResourceid == "" | StaticVariables.archesResourceid == null)


### PR DESCRIPTION
The dockpane launch buttons are disabled when the user is not logged in. Once the user submit the login info and successfully get the token, the buttons are available to click, re #56 

However, the dockpanes are already open, this implementation will not prevent the user from using them. Instead, the workflow will redirect the user to the login dockpane.