### PR TITLE
A table of resource instances created, re #63

### DIFF
--- a/arches_arcgispro_addin/CreateResource.xaml
+++ b/arches_arcgispro_addin/CreateResource.xaml
@@ -6,7 +6,7 @@
              xmlns:ui="clr-namespace:arches_arcgispro_addin"
              xmlns:extensions="clr-namespace:ArcGIS.Desktop.Extensions;assembly=ArcGIS.Desktop.Extensions"
              mc:Ignorable="d"
-             d:DesignHeight="500" d:DesignWidth="300"
+             d:DesignHeight="600" d:DesignWidth="300"
              d:DataContext="{Binding Path=ui.CreateResourceViewModel}">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -36,22 +36,34 @@
 
         <Button Content="Get Geometry Node Info" HorizontalAlignment="Center" Margin="0,100,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" Click="Button_Click" />
 
-        <TextBlock HorizontalAlignment="Center" Margin="0,138,0,0" Grid.Row="1" Text="Available Geometry Nodes" VerticalAlignment="Top"/>
+        <TextBlock HorizontalAlignment="Center" Margin="0,140,0,0" Grid.Row="1" Text="Available Geometry Nodes" VerticalAlignment="Top"/>
 
-        <ComboBox HorizontalAlignment="Center" Margin="0,158,0,0" Grid.Row="1" VerticalAlignment="Top" Width="210" SelectionChanged="ComboBox_SelectionChanged"
+        <ComboBox HorizontalAlignment="Center" Margin="0,160,0,0" Grid.Row="1" VerticalAlignment="Top" Width="210"
                 ItemsSource="{Binding GeometryNodes}" DisplayMemberPath="Id"
                 SelectedItem="{Binding SelectedGeometryNode, Mode=TwoWay}" />
 
-        <TextBlock HorizontalAlignment="Center" Margin="0,198,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
+        <TextBlock HorizontalAlignment="Center" Margin="0,200,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
             Text="2. Select a geometry and click the Submit button to create Arches geometry" />
-        <Button Content="Submit to Arches" HorizontalAlignment="Center" Margin="0,258,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" Click="Button_Click_1" />
+        <Button Name="SubmitButton" Content="Submit to Arches" HorizontalAlignment="Center" Margin="0,260,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200"
+                IsEnabled="True" Click="Button_Click_1" />
 
-        <TextBlock HorizontalAlignment="Center" Margin="0,288,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
+        <TextBlock HorizontalAlignment="Center" Margin="0,290,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
             Text="3. Continue editing attributes using Arches Resource Editor" />
-        <TextBlock HorizontalAlignment="Center" FontWeight="bold"  Margin="0,328,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
-                   Text="Resouce Instance ID being edited: " />
-        <TextBlock HorizontalAlignment="Center" FontWeight="bold"  Margin="0,348,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
-                   Text="{Binding ResourceIDEdited}" />
-        <Button Content="Edit using Arches Resource Editor" HorizontalAlignment="Center" Margin="0,378,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" Click="Button_Click_2" />
+
+        <ComboBox HorizontalAlignment="Center" Margin="0,400,0,0" Grid.Row="1" VerticalAlignment="Top" Width="210"
+                ItemsSource="{Binding ResourceIdsCreated}" DisplayMemberPath="Id"
+                SelectedItem="{Binding SelectedResourceId, Mode=TwoWay}" />
+
+        <Button Name="OpenChromiumButton" Content="Edit using Arches Resource Editor" HorizontalAlignment="Center" Margin="0,370,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" 
+                IsEnabled="False" Command="{Binding ButtonClick2}" />
+
+        <TextBlock HorizontalAlignment="Left" Margin="25,470,0,0" Grid.Row="1" VerticalAlignment="Top" Width="125" TextWrapping="WrapWithOverflow"
+            Text="The Resources Created" />
+        <Button Content="Clear the List" HorizontalAlignment="Right" Margin="180,470,25,0" Grid.Row="1" VerticalAlignment="Top" Width="100" Click="Button_Click_3"/>
+
+        <DataGrid HorizontalAlignment="Stretch" Height="Auto" Margin="0,500,0,0" Grid.Row="1" VerticalAlignment="Top" Width="Auto"
+              ItemsSource="{Binding ResourceIdsCreated}" Style="{DynamicResource Esri_DataGrid}" 
+              HeadersVisibility="None" AutoGenerateColumns="True" IsReadOnly="True" SelectionMode="Single" RowHeaderWidth="0"/>
+
     </Grid>
 </UserControl>

--- a/arches_arcgispro_addin/CreateResource.xaml.cs
+++ b/arches_arcgispro_addin/CreateResource.xaml.cs
@@ -126,8 +126,10 @@ namespace arches_arcgispro_addin
                 string geometryFormat = "esrijson";
                 var result = await SaveResourceView.SubmitToArches(null, StaticVariables.archesNodeid, archesGeometryString, geometryFormat);
                 StaticVariables.archesResourceid = result["resourceinstance_id"];
+                CreateResourceViewModel.GetResourceIdsCreated();
                 ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show($"A resource id: \n{StaticVariables.archesResourceid} is assigned");
                 SaveResourceView.RefreshMapView();
+                OpenChromiumButton.IsEnabled = true;
             }
             catch (Exception ex)
             {
@@ -135,32 +137,10 @@ namespace arches_arcgispro_addin
             }
         }
 
-        private void Button_Click_2(object sender, RoutedEventArgs e)
+        private void Button_Click_3(object sender, RoutedEventArgs e)
         {
-            if (StaticVariables.myInstanceURL == "" | StaticVariables.myInstanceURL == null)
-            {
-                ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Log in to Arches Server...");
-
-                DockPane pane = FrameworkApplication.DockPaneManager.Find("arches_arcgispro_addin_MainDockpane");
-                if (pane == null)
-                    return;
-                pane.Activate();
-                return;
-            }
-            if (StaticVariables.archesResourceid == "" | StaticVariables.archesResourceid == null)
-            {
-                ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Submit a Geometry to Arches to Create a Resource...");
-                return;
-            }
-            string editorAddress = StaticVariables.myInstanceURL + $"resource/{StaticVariables.archesResourceid}";
-            ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("opening... \n" + editorAddress);
-            UI.ChromePaneViewModel.OpenChromePane(editorAddress);
-
-        }
-
-        private void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-
+            CreateResourceViewModel.ClearResourceIdsCreated();
+            OpenChromiumButton.IsEnabled = false;
         }
     }
 }

--- a/arches_arcgispro_addin/CreateResourceViewModel.cs
+++ b/arches_arcgispro_addin/CreateResourceViewModel.cs
@@ -21,16 +21,75 @@ using ArcGIS.Desktop.Core.Events;
 using ArcGIS.Desktop.Mapping.Events;
 using System.Web.Script.Serialization;
 using System.Net.Http;
+using System.Windows.Input;
 
 namespace arches_arcgispro_addin
 {
+    public class ResourceInstance
+    {
+        public string Name { get; set; }
+        public string Id { get; set; }
+        public string Model { get; set; }
+        public ResourceInstance(string inId)
+        {
+            Name = "";
+            Id = inId;
+            Model = "";
+        }
+        public ResourceInstance(string inName, string inId, string inModel)
+        {
+            Name = inName;
+            Id = inId;
+            Model = inModel;
+        }
+    }
+
     internal class CreateResourceViewModel : DockPane
     {
         private const string _dockPaneID = "arches_arcgispro_addin_CreateResource";
 
         public static ObservableCollection<GeometryNode> _geometryNodes = new ObservableCollection<GeometryNode>();
+        public static ObservableCollection<ResourceInstance> _resourceIdsCreated = new ObservableCollection<ResourceInstance>();
+        private static readonly object _lockCollections = new object();
+        private static int counter_created = 1;
 
-        protected CreateResourceViewModel() {
+        protected CreateResourceViewModel()
+        {
+            BindingOperations.EnableCollectionSynchronization(_resourceIdsCreated, _lockCollections);
+        }
+
+        public ObservableCollection<ResourceInstance> ResourceIdsCreated
+        {
+            set
+            {
+                SetProperty(ref _resourceIdsCreated, value, () => ResourceIdsCreated);
+            }
+            get { return _resourceIdsCreated; }
+        }
+
+        private ResourceInstance _selectedResourceId = new ResourceInstance("");
+
+        public ResourceInstance SelectedResourceId
+        {
+            get { return _selectedResourceId; }
+            set
+            {
+                SetProperty(ref _selectedResourceId, value, () => SelectedResourceId);
+            }
+        }
+
+        public static void GetResourceIdsCreated()
+        {
+            lock(_lockCollections);
+            ResourceInstance newResourceId = new ResourceInstance("ArcGIS-" + counter_created, StaticVariables.archesResourceid, "");
+            counter_created += 1;
+            _resourceIdsCreated.Add(newResourceId);
+        }
+
+        public static void ClearResourceIdsCreated()
+        {
+            lock(_lockCollections);
+            _resourceIdsCreated.Clear();
         }
 
         public static void CreateNodeList()
@@ -64,6 +123,47 @@ namespace arches_arcgispro_addin
             }
         }
 
+        private ICommand _buttonClick2;
+        public ICommand ButtonClick2
+        {
+            get
+            {
+                return _buttonClick2 ?? (_buttonClick2 = new RelayCommand(() =>
+                {
+                    if (StaticVariables.myInstanceURL == "" | StaticVariables.myInstanceURL == null)
+                    {
+                        ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Log in to Arches Server...");
+
+                        DockPane pane = FrameworkApplication.DockPaneManager.Find("arches_arcgispro_addin_MainDockpane");
+                        if (pane == null)
+                            return;
+                        pane.Activate();
+                        return;
+                    }
+                    if (StaticVariables.archesResourceid == "" | StaticVariables.archesResourceid == null)
+                    {
+                        ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Submit a Geometry to Arches to Create a Resource...");
+                        return;
+                    }
+                    if (SelectedResourceId == null)
+                    {
+                        ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Choose a Resource ID from the Dropdown");
+                        return;
+                    }
+                    if (SelectedResourceId.Id == "")
+                    {
+                        ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Please, Choose a Resource ID from the Dropdown");
+                        return;
+                    }
+                    string editorAddress = StaticVariables.myInstanceURL + $"resource/{SelectedResourceId.Id}";
+                    ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("opening... \n" + editorAddress);
+                    UI.ChromePaneViewModel.OpenChromePane(editorAddress);
+
+                }, true));
+            }
+        }
+
+
         /// <summary>
         /// Show the DockPane.
         /// </summary>
@@ -79,7 +179,7 @@ namespace arches_arcgispro_addin
         /// <summary>
         /// Text shown near the top of the DockPane.
         /// </summary>
-        private string _heading = "Create a Resource";
+        private string _heading = "Create Resources";
         public string Heading
         {
             get { return _heading; }

--- a/arches_arcgispro_addin/SaveResource.xaml.cs
+++ b/arches_arcgispro_addin/SaveResource.xaml.cs
@@ -37,45 +37,6 @@ namespace arches_arcgispro_addin
             InitializeComponent();
         }
 
-        /*private async void GetAttribute()
-        {
-            await QueuedTask.Run(() =>
-            {
-                var selectedFeatures = MapView.Active.Map.GetSelection();
-                if (selectedFeatures.Count == 1)
-                {
-                    var firstSelectionSet = selectedFeatures.First();
-                    if (firstSelectionSet.Value.Count == 1)
-                    {
-                        var archesInspector = new Inspector();
-                        archesInspector.Load(firstSelectionSet.Key, firstSelectionSet.Value);
-                        var archesGeometry = archesInspector.Shape;
-                        try
-                        {
-                            StaticVariables.archesResourceid = archesInspector["resourceinstanceid"].ToString();
-                            StaticVariables.archesTileid = archesInspector["tileid"].ToString();
-                            StaticVariables.archesNodeid = archesInspector["nodeid"].ToString();
-
-                            ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show($"Resource Instance is registered: \n{StaticVariables.archesResourceid}");
-                        }
-                        catch (Exception ex)
-                        {
-                            ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Make Sure to Select a Geometry from a valid Arches Layer");
-                            ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(ex.Message);
-                        }
-                    }
-                    else
-                    {
-                        ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Make Sure to Select ONE valid geometry");
-                    }
-                }
-                else 
-                {
-                    ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Make Sure to Select from ONE Arches Layer");
-                }
-            });
-        }*/
-
         private static ArcGIS.Core.Geometry.Geometry SRTransform(ArcGIS.Core.Geometry.Geometry inGeometry, int inSRID, int outSRID)
         {
             ArcGIS.Core.Geometry.Geometry outGeometry;

--- a/arches_arcgispro_addin/SaveResourceViewModel.cs
+++ b/arches_arcgispro_addin/SaveResourceViewModel.cs
@@ -45,13 +45,6 @@ namespace arches_arcgispro_addin
         }
 
         /// <summary>
-        /// Called when the pane is first created to give it the opportunity to initialize itself asynchronously.
-        /// </summary>
-        /// <returns>
-        /// A task that represents the work queued to execute in the ThreadPool.
-        /// </returns>
-
-        /// <summary>
         /// Show the DockPane.
         /// </summary>
         internal static void Show()


### PR DESCRIPTION
Add a table of resource instances recently created, re #63 

1. Add a table of recently created resource instances in the Create Dockpane
2. Also add link to the Arches resource editor with a dropdown menu for selection

It will add a name field with the format, ArcGIS-xx, which at the moment only for ArcGIS Pro UI.
Later it may be apply to Arches Resource Instance.