### PR TITLE
checkbox for replace, re #70

### DIFF
--- a/arches_arcgispro_addin/CreateResource.xaml.cs
+++ b/arches_arcgispro_addin/CreateResource.xaml.cs
@@ -124,7 +124,8 @@ namespace arches_arcgispro_addin
                 ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show($"{archesGeometryString} is submitted" +
                                                                  $"\n to {StaticVariables.archesNodeid}");
                 string geometryFormat = "esrijson";
-                var result = await SaveResourceView.SubmitToArches(null, StaticVariables.archesNodeid, archesGeometryString, geometryFormat);
+                string submitOperation = "create";
+                var result = await SaveResourceView.SubmitToArches(null, StaticVariables.archesNodeid, archesGeometryString, geometryFormat, submitOperation);
                 StaticVariables.archesResourceid = result["resourceinstance_id"];
                 CreateResourceViewModel.GetResourceIdsCreated();
                 ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show($"A resource id: \n{StaticVariables.archesResourceid} is assigned");

--- a/arches_arcgispro_addin/MainDockpane.xaml.cs
+++ b/arches_arcgispro_addin/MainDockpane.xaml.cs
@@ -51,6 +51,7 @@ namespace arches_arcgispro_addin
         public static string archesTileid;
         public static string archesNodeid;
         public static string archesResourceid = "No Resource is Selected";
+        public static ArcGIS.Core.Geometry.Geometry archesGeometry;
         public static List<GeometryNode> geometryNodes = new List<GeometryNode>();
     };
     public partial class MainDockpaneView : UserControl

--- a/arches_arcgispro_addin/SaveResource.xaml
+++ b/arches_arcgispro_addin/SaveResource.xaml
@@ -40,7 +40,7 @@
 
         <TextBlock HorizontalAlignment="Left" Margin="50,210,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
             Text="2. Select a geometry and click the Submit button to Add" />
-        <CheckBox Content="Replace the Exsiting Geometry?" HorizontalAlignment="Left" Margin="50,250,0,0" Grid.Row="1" VerticalAlignment="Top" Checked="CheckBox_Checked" RenderTransformOrigin="0.121,0.4"/>
+        <CheckBox Content="Replace the Exsiting Geometry?" HorizontalAlignment="Left" Margin="50,250,0,0" Grid.Row="1" VerticalAlignment="Top" Unchecked="CheckBox_Unchecked" Checked="CheckBox_Checked" RenderTransformOrigin="0.121,0.4"/>
         <Button Content="Submit to Arches" HorizontalAlignment="Center" Margin="0,290,0,0" Grid.Row="1" VerticalAlignment="Top" Width="150" Click="Button_Click_2" RenderTransformOrigin="0.741,1.819"/>
 
         <TextBlock HorizontalAlignment="Left" Margin="50,330,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"

--- a/arches_arcgispro_addin/SaveResource.xaml
+++ b/arches_arcgispro_addin/SaveResource.xaml
@@ -39,10 +39,11 @@
         <Button Content="Unregister Arches Instance" HorizontalAlignment="Center" Margin="0,170,0,0" Grid.Row="1" VerticalAlignment="Top" Width="180" Command="{Binding ButtonClick1}" />
 
         <TextBlock HorizontalAlignment="Left" Margin="50,210,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
-            Text="2. Select a geometry and click the Submit button to replace Arches geometry" />
-        <Button Content="Submit to Arches" HorizontalAlignment="Center" Margin="0,270,0,0" Grid.Row="1" VerticalAlignment="Top" Width="150" Click="Button_Click_2" RenderTransformOrigin="0.741,1.819"/>
+            Text="2. Select a geometry and click the Submit button to Add" />
+        <CheckBox Content="Replace the Exsiting Geometry?" HorizontalAlignment="Left" Margin="50,250,0,0" Grid.Row="1" VerticalAlignment="Top" Checked="CheckBox_Checked" RenderTransformOrigin="0.121,0.4"/>
+        <Button Content="Submit to Arches" HorizontalAlignment="Center" Margin="0,290,0,0" Grid.Row="1" VerticalAlignment="Top" Width="150" Click="Button_Click_2" RenderTransformOrigin="0.741,1.819"/>
 
-        <TextBlock HorizontalAlignment="Left" Margin="50,310,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
+        <TextBlock HorizontalAlignment="Left" Margin="50,330,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"
             Text="3. Continue editing attributes using Arches Resource Editor" />
         
         <TextBlock HorizontalAlignment="Left" FontWeight="bold"  Margin="50,400,0,0" Grid.Row="1" VerticalAlignment="Top" Width="200" TextWrapping="WrapWithOverflow"

--- a/arches_arcgispro_addin/SaveResource.xaml.cs
+++ b/arches_arcgispro_addin/SaveResource.xaml.cs
@@ -58,11 +58,6 @@ namespace arches_arcgispro_addin
             {
                 var selectedFeatures = ArcGIS.Desktop.Mapping.MapView.Active.Map.GetSelection();
 
-                if (!GeometryBeReplaced)
-                {
-                    selectedGeometryCollection.Add(StaticVariables.archesGeometry.ToJson());
-                }
-
                 foreach (var selectedFeature in selectedFeatures)
                 {
                     foreach (var selected in selectedFeature.Value)
@@ -91,17 +86,20 @@ namespace arches_arcgispro_addin
         public static async Task<Dictionary<string, string>> SubmitToArches(string tileid, string nodeid, string esrijson, string geometryFormat)
         {
             Dictionary<String, String> result = new Dictionary<String, String>();
-
             try
             {
                 var serializer = new JavaScriptSerializer();
+                string submitOperation = (GeometryBeReplaced) ? "replace" : "append";
+
                 var stringContent = new FormUrlEncodedContent(new[]
                     {
                         new KeyValuePair<string, string>("tileid", tileid),
                         new KeyValuePair<string, string>("nodeid", nodeid),
                         new KeyValuePair<string, string>("data", esrijson),
                         new KeyValuePair<string, string>("format", geometryFormat),
+                        new KeyValuePair<string, string>("operation", submitOperation),
                     });
+
                 client.DefaultRequestHeaders.Authorization = 
                     new AuthenticationHeaderValue("Bearer", StaticVariables.myToken["access_token"]);
                 var response = await client.PostAsync(System.IO.Path.Combine(StaticVariables.myInstanceURL, "api/tiles/"), stringContent);
@@ -192,6 +190,11 @@ namespace arches_arcgispro_addin
         private void CheckBox_Checked(object sender, RoutedEventArgs e)
         {
             GeometryBeReplaced = true;
+        }
+
+        private void CheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            GeometryBeReplaced = false;
         }
     }
 }

--- a/arches_arcgispro_addin/SaveResource.xaml.cs
+++ b/arches_arcgispro_addin/SaveResource.xaml.cs
@@ -58,18 +58,8 @@ namespace arches_arcgispro_addin
             {
                 var selectedFeatures = ArcGIS.Desktop.Mapping.MapView.Active.Map.GetSelection();
 
-                if (GeometryBeReplaced)
-                {
-                    ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Replacing...");
-                }
-                else
-                {
-                    ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Appending...");
-                }
-
                 if (!GeometryBeReplaced)
                 {
-                    ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Adding Original: \n" + StaticVariables.archesGeometry.ToJson());
                     selectedGeometryCollection.Add(StaticVariables.archesGeometry.ToJson());
                 }
 

--- a/arches_arcgispro_addin/SaveResource.xaml.cs
+++ b/arches_arcgispro_addin/SaveResource.xaml.cs
@@ -83,14 +83,12 @@ namespace arches_arcgispro_addin
             return args;
         }
 
-        public static async Task<Dictionary<string, string>> SubmitToArches(string tileid, string nodeid, string esrijson, string geometryFormat)
+        public static async Task<Dictionary<string, string>> SubmitToArches(string tileid, string nodeid, string esrijson, string geometryFormat, string submitOperation)
         {
             Dictionary<String, String> result = new Dictionary<String, String>();
             try
             {
                 var serializer = new JavaScriptSerializer();
-                string submitOperation = (GeometryBeReplaced) ? "replace" : "append";
-
                 var stringContent = new FormUrlEncodedContent(new[]
                     {
                         new KeyValuePair<string, string>("tileid", tileid),
@@ -154,7 +152,9 @@ namespace arches_arcgispro_addin
 
                 string archesGeometryString = await GetGeometryString();
                 string geometryFormat = "esrijson";
-                var result = await SubmitToArches(StaticVariables.archesTileid.ToString(), StaticVariables.archesNodeid, archesGeometryString, geometryFormat);
+                string submitOperation = (GeometryBeReplaced) ? "replace" : "append";
+
+                var result = await SubmitToArches(StaticVariables.archesTileid.ToString(), StaticVariables.archesNodeid, archesGeometryString, geometryFormat, submitOperation);
                 //var message = result["results"];
                 ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show($"\n{archesGeometryString} is submitted");
                 RefreshMapView();


### PR DESCRIPTION
Add a checkbox for replace in the edit dockpane, re #70 

A checkbox is added to give users to options to choose between replace and append and the API request is modified to include the operation as a parameter. (replace, append, or create)