### PR TITLE
Proxy support for outbound HTTP requests #93

### DIFF
--- a/arches_arcgispro_addin/CreateResource.xaml.cs
+++ b/arches_arcgispro_addin/CreateResource.xaml.cs
@@ -36,12 +36,12 @@ namespace arches_arcgispro_addin
         {
             InitializeComponent();
         }
-        static readonly HttpClient client = new HttpClient();
         public static async Task<List<GeometryNode>> GetGeometryNode()
         {
             List<GeometryNode> nodeidResponse = new List<GeometryNode>();
             try
             {
+                HttpClient client = await ArchesHttpClient.GetHttpClient();
                 if ((DateTime.Now - StaticVariables.archesToken["timestamp"]).TotalSeconds > (StaticVariables.archesToken["expires_in"] - 300)) 
                 {
                     StaticVariables.archesToken = await MainDockpaneView.RefreshToken(StaticVariables.myClientid);

--- a/arches_arcgispro_addin/SaveResource.xaml.cs
+++ b/arches_arcgispro_addin/SaveResource.xaml.cs
@@ -30,7 +30,6 @@ namespace arches_arcgispro_addin
     /// </summary>
     public partial class SaveResourceView : UserControl
     {
-        static readonly HttpClient client = new HttpClient();
         public static Boolean GeometryBeReplaced;
 
         public SaveResourceView()
@@ -88,6 +87,7 @@ namespace arches_arcgispro_addin
             Dictionary<String, String> result = new Dictionary<String, String>();
             try
             {
+                HttpClient client = await ArchesHttpClient.GetHttpClient();
                 if ((DateTime.Now - StaticVariables.archesToken["timestamp"]).TotalSeconds > (StaticVariables.archesToken["expires_in"] - 300))
                 {
                     StaticVariables.archesToken = await MainDockpaneView.RefreshToken(StaticVariables.myClientid);

--- a/arches_arcgispro_addin/SaveResourceViewModel.cs
+++ b/arches_arcgispro_addin/SaveResourceViewModel.cs
@@ -41,7 +41,6 @@ namespace arches_arcgispro_addin
     {
         private const string _dockPaneID = "arches_arcgispro_addin_SaveResource";
 
-        static readonly HttpClient client = new HttpClient();
 
         private string _resourceIdEdited;
         private ICommand _editRegister_Button;
@@ -169,6 +168,7 @@ namespace arches_arcgispro_addin
 
             try
             {
+                HttpClient client = await ArchesHttpClient.GetHttpClient();
                 if ((DateTime.Now - StaticVariables.archesToken["timestamp"]).TotalSeconds > (StaticVariables.archesToken["expires_in"] - 300))
                 {
                     StaticVariables.archesToken = await MainDockpaneView.RefreshToken(StaticVariables.myClientid);


### PR DESCRIPTION
Regarding issue #93 

This change provides a singleton HttpClient (comments in the code suggested only one HttpClient instance per application) that will test for a 407 webexception and apply basic proxy handler using network credentials.

It uses the system configured proxy. It does not provide the user with the ability to set the proxy and credentials.

This has been tested within our firewall and by remote use on and off a VPN.