### PR TITLE
Prepare files for an official v2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,33 @@
 # arches-esri-add-in
-An ESRI add-in that will interface with a Koop.js service backed by an Arches data store. This add-in requires both the installation of the ArcGIS Pro add-in and the installation and configuation of a koop.js server configured to serve data from an Arches installation. 
+
+An ArcGIS Pro add-in that provides geometry editing capabilities for Arches, and provides a quick access workflow for editing Arches records. This is used in conjunction with Arches spatial views which provide a data source for layers in ArcGIS Pro 
 
 ## System Requirements
-ArcGIS Pro v2.5(?)  
-Arches v5.2.x(?) Deployment  
-Arches-Koop  
+
+- ArcGIS Pro v3.x
+- Arches v6.0+
 
 
 ## How to install and use the Arches-Esri addin
 
 ### Download and install Arches-Esri add-in
+
 1. Select the branch that corresponds with the version of the plugin you would like to install.
 2. Download the .esriAddinX file from `arches_arcgispro_addin/dist` folder
 3. Once downloaded, double click the add in to install or follow the instructions found [here](https://pro.arcgis.com/en/pro-app/latest/get-started/manage-add-ins.htm)
 4. Follow instructions to install and configure koop on your Arches server.
 
-### Installing koop on your Arches server
-1. Clone the koop [repository](https://github.com/archesproject/arches-koop) on your Arches server.
-2. Navigate to the root folder of the repository and run `yarn install`
-3. Koop.js has an issue with the spatial transformation. Although ArcGIS Pro sends the valid spatial reference wkid, it does not pass the koop.js’ validation step. As a result the reprojection to some coordinate systems fails, including British National Grid. Here is a work-around the issue. The change will let users bypass the validation steps. (Note that this can cause an error in koop.js if a client application other than except for ArcGIS Pro is used with a Spatial Reference is indeed invalid). Make the following modifications:
-    
-    ```
-    file: /arches-koop/node_modules/winnow/lib/normalize-query-options/spatial-reference.js  
-    instruction: comment out lines 19-27
-    
-    file: /arches-koop/node_modules/featureserver/dist/geometry/normalize-spatial-reference.js  
-    instruction: comment out lines 18-27
-    
-    file: /arches-koop/node_modules/winnow/lib/normalize-query-options/geometry-filter-spatial-reference.js  
-    instruction: comment out line 18
-    ```
+### Adding Arches spatial layers into ArcGIS Pro
 
-### Configuring koop on your Arches server
-1. Edit the config file (arches-koop/config/development.json) based on the Arches [geojson api](https://arches.readthedocs.io/en/stable/api/#geojson)
+To add spatial data into ArcGIS Pro from Arches, you will firstly need to configure one or more spatial views to provide you with a data source.
 
-  "url": for the Arches server  
-  "nodeid": geometry node  
-  "nodegroup": the values that you want to include as the properties, multiple nodegroupa can be added, separated by commas  
-  "type": geometry type (from Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon) you will have to check the response to confirm your selection  
-  "properties: to map the incoming properties for the specified nodegroups to the attribute names for ArcGIS  
-   
-   Other parameters for the Arches geojson API can also be added, such as "use_display_values": true
+Instructions on creating these spatial views can be found in the official Arches documentation [here](https://arches.readthedocs.io/en/stable/administering/spatial-views/).
 
-2. To start the koop.js development server run `yarn start` from the root of the arches-koop application
-3. Koop will run at the port 8080 by default, this can be changed in arches-koop/config/default.json if necessary.
+Then in ArcGIS Pro, create a database connection to the Arches database using the credentials found [here](https://arches.readthedocs.io/en/stable/administering/spatial-views/#using-the-spatial-views).  Note that if you, or your IT team have configured different credentials, you will need to use those instead.
+
+You should then be able to use the ArcGIS Pro Catalog to open the connection and add the data sources to the map.
+
+If you do not have direct database access, then it will be necessary for your IT or GIS team to provide a service that connects to that data source.
 
 ## What you need to develop the Arches-ArcGIS Pro addin
 
@@ -55,6 +39,3 @@ https://pro.arcgis.com/en/pro-app/sdk/
 
 ##### Installation Guide
 https://github.com/Esri/arcgis-pro-sdk/wiki/ProGuide-Installation-and-Upgrade
-
-### Arches Koop Application (Local Koop Server for development)
-https://github.com/archesproject/arches-koop

--- a/arches_arcgispro_addin/Config.daml
+++ b/arches_arcgispro_addin/Config.daml
@@ -2,7 +2,7 @@
 <ArcGIS defaultAssembly="arches_arcgispro_addin.dll" defaultNamespace="arches_arcgispro_addin" xmlns="http://schemas.esri.com/DADF/Registry" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.esri.com/DADF/Registry file:///C:/Program%20Files/ArcGIS/Pro/bin/ArcGIS.Desktop.Framework.xsd">
   <AddInInfo id="{ef079a8b-4d20-43cd-92c7-e76e4280243a}" version="1.0" desktopVersion="3.2.49743">
     <Name>arches_arcgispro_addin</Name>
-    <Description>An ESRI add-in that will interface with a Koop.js service backed by an Arches data store</Description>
+    <Description>An ESRI add-in that enables editing geometries in an Arches data store.</Description>
     <Image>Images\AddinDesktop32.png</Image>
     <Author>Farallon Geographics</Author>
     <Company>Acme</Company>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,45 +1,50 @@
 # Arches ArcGIS Pro Add-in
 
-### Abstract
   The Arches Add-In for ArcGIS Pro allows Arches users to access and manage their Arches data from within ArcGIS Pro. The Add-In works with Arches spatial views to display existing Arches data within ArcGIS Pro via direct database connections or other GIS services. The Add-In allows user to perform two basic operations: edit existing geometry data and create new geometry data.
   
-### [Prerequisites](#prerequisites)
-### [Installing the Add-In](#installing-the-add-in)
-### [Adding Arches spatial layers into ArcGIS Pro](#adding-arches-spatial-layers-into-arcgis-pro)
-### [Logging Into Arches](#logging-into-arches)
-### [Editing an Existing Resource](#editing-an-existing-resource)
-### [Creating a New Resource](#creating-a-new-resource)
+  **[Prerequisites](#prerequisites)**
+  **[Installing the Add-In](#installing-the-add-in)**
+  **[Adding Arches spatial layers into ArcGIS Pro](#adding-arches-spatial-layers-into-arcgis-pro)**
+  **[Logging Into Arches](#logging-into-arches)**
+  **[Editing an Existing Resource](#editing-an-existing-resource)**
+  **[Creating a New Resource](#creating-a-new-resource)**
   
+## Prerequisites
+
+  The following is required to use the Arches Add-In for ArcGIS Pro:
+
+  1. ArcGIS Pro v3.x
+  2. Arches v6.0+
+  3. Arches spatial views configured to provide data sources for layers in ArcGIS Pro
   
-### Prerequisites
-  - ArcGIS Pro v3.x
-  - Arches v6.0+
-  - Arches spatial views configured to provide data sources for layers in ArcGIS Pro
-  
-### Installing the Add-In
+## Installing the Add-In
+
   To install the Arches download it to the same computer you have ArcGIS Pro installed on. Double click the Add-In to automatically install it to ArcGIS Pro.
   
-### Adding Arches spatial layers into ArcGIS Pro
+## Adding Arches spatial layers into ArcGIS Pro
+
   To add spatial data into ArcGIS Pro from Arches, you will firstly need to configure one or more spatial views to provide you with a data source.
   
-  Instructions on creating these spatial views can be found in the official Arches documentation [here](https://arches.readthedocs.io/en/stable/administering/spatial-views/).
+  Instructions on creating these spatial views can be found in the [official Arches documentation](https://arches.readthedocs.io/en/stable/administering/spatial-views/).
   
-  Then in ArcGIS Pro, create a database connection to the Arches database using the credentials found [here](https://arches.readthedocs.io/en/stable/administering/spatial-views/#using-the-spatial-views). Note that if you, or your IT team have configured different credentials, you will need to use those instead.
+  After creating these views you can add them to ArcGIS Pro using a direct database connection or having set them as a data source for a service. Due to a [bug in ArcGIS Pro prior to version 3.5](https://support.esri.com/en-us/bug/arcgis-pro-does-not-refresh-layers-from-the-ogc-api-fea-bug-000147359), OGC compliant services may not refresh properly. For that reason publishing services using ArcGIS Server is currently recommended.
   
   You should then be able to use the ArcGIS Pro Catalog to open the connection and add the data sources to the map.
-  
-  If you do not have direct database access, then it will be necessary for your IT or GIS team to provide a service that connects to that data source.
 
-### Logging Into Arches
+## Logging Into Arches
+
   In order to use the plugin the user must login to an existing deployment of Arches. Follow these step by step instructions to login to your deployment of Arches.
+
    1. First click the 'Arches Project' tab of the dockpane at the top of the ArcGIS Pro window. 
    2. Next click 'Arches Connection' from the 'Arches Project' tab.
    3. Under 'Arches Server URL' type the URL of your Arches deployment (make sure to include 'http://' and a trailing '/')
    4. For User Name and Password login as the Arches user you would like to edit as (Note: the user will need to have the correct permissions in your Arches deployment to create and/or edit a resource in order to create/edit a resource in the Add-In.)
    5. Finally click 'Connect'. Upon successful connection a message should appear in the dialog box saying 'Connected to Arches Server'
-   
-### Editing an Existing Resource
+
+## Editing an Existing Resource
+
   The following steps outline how to edit an existing Arches geometry with the Arches-Esri Add-In
+
    1. Add your Arches spatial layer(s) to the map, if you have not already (see the section on Adding Arches spatial layers above).
    2. Click 'Edit Resource' either in the 'Arches Project' tab in the dockpane or at the bottom of the Arches Project Add-In panel.
    3. Next choose 'Select' from the 'ArcGIS Pro Tools' section of the 'Arches Project' dock pane tab.
@@ -51,8 +56,8 @@
    After editing a geometry the spatial layer should refresh to reflect your changes in ArcGIS Pro. You can also view the edits immediately by clicking the 'Edit Using Arches Resource Editor' button at the bottom of the 'Edit Resource' tab of the Add-In.
 
 ### Creating a New Resource
+
   1. To create a new resource click 'Create Resource' in the 'Arches Project' dockpane or click the 'Create Resource' tab at the bottom of the Arches Add-In.
   2. In the 'Create Resource' tab select resource model and node you would like to create geometry for from the 'Select a Resource Type' dropdown. Note: If you do not see any resource models listed, check the Arches server or your user permissions.
   3. Select a geometry/geometries from the map that you would like to assign to the new resource.
   4. Click 'Upload Geometry to Arches' to create the new resource geometry in Arches.
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,26 +1,34 @@
 # Arches ArcGIS Pro Add-in
 
 ### Abstract
-  The Arches Add-In for ArcGIS Pro allows Arches users to access and manage their Arches data from within ArcGIS Pro. The Add-In leverages Koop geoservices (https://github.com/archesproject/arches-koop) to display existing Arches data within ArcGIS Pro. The Add-In allows user to perform two basic operations: edit existing geometry data and create new geometry data.
+  The Arches Add-In for ArcGIS Pro allows Arches users to access and manage their Arches data from within ArcGIS Pro. The Add-In works with Arches spatial views to display existing Arches data within ArcGIS Pro via direct database connections or other GIS services. The Add-In allows user to perform two basic operations: edit existing geometry data and create new geometry data.
   
 ### [Prerequisites](#prerequisites)
 ### [Installing the Add-In](#installing-the-add-in)
-### [Setting Up Koop services](#setting-up-koop-services)
+### [Adding Arches spatial layers into ArcGIS Pro](#adding-arches-spatial-layers-into-arcgis-pro)
 ### [Logging Into Arches](#logging-into-arches)
 ### [Editing an Existing Resource](#editing-an-existing-resource)
 ### [Creating a New Resource](#creating-a-new-resource)
   
   
 ### Prerequisites
-  - ArcGIS Pro (v2.5)
-  - Arches v5
-  - A Koop service to display geometry data from your Arches instance
+  - ArcGIS Pro v3.x
+  - Arches v6.0+
+  - Arches spatial views configured to provide data sources for layers in ArcGIS Pro
   
 ### Installing the Add-In
   To install the Arches download it to the same computer you have ArcGIS Pro installed on. Double click the Add-In to automatically install it to ArcGIS Pro.
   
-### Setting Up Koop services
-  The Arches-Esri Add-In relies Arches Koop to display Arches resource instance data in ArcGIS Pro. Arches Koop is a node application/server that translates Arches geojson data to an Esri geoservice that can be consumed by ArcGIS Online and ArcGIS Pro. For instructions on setting up a Koop service to serve your Arches data please visit the Arches-Koop repository here: https://github.com/archesproject/arches-koop
+### Adding Arches spatial layers into ArcGIS Pro
+  To add spatial data into ArcGIS Pro from Arches, you will firstly need to configure one or more spatial views to provide you with a data source.
+  
+  Instructions on creating these spatial views can be found in the official Arches documentation [here](https://arches.readthedocs.io/en/stable/administering/spatial-views/).
+  
+  Then in ArcGIS Pro, create a database connection to the Arches database using the credentials found [here](https://arches.readthedocs.io/en/stable/administering/spatial-views/#using-the-spatial-views). Note that if you, or your IT team have configured different credentials, you will need to use those instead.
+  
+  You should then be able to use the ArcGIS Pro Catalog to open the connection and add the data sources to the map.
+  
+  If you do not have direct database access, then it will be necessary for your IT or GIS team to provide a service that connects to that data source.
 
 ### Logging Into Arches
   In order to use the plugin the user must login to an existing deployment of Arches. Follow these step by step instructions to login to your deployment of Arches.
@@ -32,17 +40,15 @@
    
 ### Editing an Existing Resource
   The following steps outline how to edit an existing Arches geometry with the Arches-Esri Add-In
-   1. Add your koop service layer(s) to the map, if you have not already.
-      1. From the 'ArcGIS Pro Tools' section of the 'Arches Project' dock pane tab, select 'Add Data' -> 'Data from Path'
-      2. On the next screen add the path of the Koop layer you would like to add. To add multiple layers you will have to repeat steps for each layer.
+   1. Add your Arches spatial layer(s) to the map, if you have not already (see the section on Adding Arches spatial layers above).
    2. Click 'Edit Resource' either in the 'Arches Project' tab in the dockpane or at the bottom of the Arches Project Add-In panel.
    3. Next choose 'Select' from the 'ArcGIS Pro Tools' section of the 'Arches Project' dock pane tab.
-   4. Select the an Arches resource instance from one of the Koop layers you added before. Make sure to select one and just one instance.
+   4. Select an Arches resource instance from one of the Arches spatial layers you added before. Make sure to select one and just one instance.
    5. Once selected, press the 'Register Feature with Arches' button to indicate that this is the feature that you wish to edit.
    6. Now select the geometry(ies) that you wish to append to or replace the registered geometry.
-   7. By default the plugin will append the selected geometries to the registered geometry. If you would like to completely relace the registered geometry, check         the 'Replace existing geometry' checkbox.
+   7. By default the plugin will append the selected geometries to the registered geometry. If you would like to completely replace the registered geometry, check the 'Replace existing geometry' checkbox.
    8. Finally, click upload to send your new geometries to your Arches instance.
-   After editing a geometry the Koop service should refresh to reflect your changes in ArcGIS Pro. You can also view the edits immediately by clicking the 'Edit        Using Arches Resource Editor' button at the bottom of the 'Edit Resource' tab of the Add-In.
+   After editing a geometry the spatial layer should refresh to reflect your changes in ArcGIS Pro. You can also view the edits immediately by clicking the 'Edit Using Arches Resource Editor' button at the bottom of the 'Edit Resource' tab of the Add-In.
 
 ### Creating a New Resource
   1. To create a new resource click 'Create Resource' in the 'Arches Project' dockpane or click the 'Create Resource' tab at the bottom of the Arches Add-In.

--- a/releases/2.0.0.md
+++ b/releases/2.0.0.md
@@ -1,0 +1,22 @@
+## Arches ESRI Add-in for ArcGIS Pro - Release Notes
+
+### New Features
+
+- Moves support from ArcGIS Pro 2.x to 3.x. due to .NET Framework change (Details at arcgis.com - [Migration from ArcGIS Pro 2.x to 3.x](https://pro.arcgis.com/en/pro-app/latest/get-started/migrate-2x-to-3.htm#ESRI_SECTION1_256FE93FEA6E4EB1B1F6FB350651FAFD))
+- Uses local default browser instead of builtin browser for viewing Arches.
+
+### Change List
+
+- Project has been updated and migrated to work with ArcGIS Pro 3.2+ and Visual Studio 2022
+- Integrated browser functionality has been removed (Cef Chromium browser)
+- Previous integrated browser calls to Arches e.g. .../resource/{UUID} now get sent to the user's external default web browser
+- When Creating Resources, the Uploaded Features grid shows the Resource Type
+- Uploaded Features grid - double-click on a row opens that resource in Arches via external default web browser
+- Arches instance URL and username is now persisted to the HKEY_CURRENT_USER registry upon successful log-in
+- On the Arches Connection panel, the Cancel button removes the details stored in HKEY_CURRENT_USER - in case of shared PC situation without separate log-in to PC
+- Remove the Open Chromium ribbon item and replaced with Open Arches, which opens Arches as defined against the Arches instance URL
+All changes were completed in [PR 148](https://github.com/archesproject/arches-esri-add-in/pull/148)
+
+### Breaking changes
+
+-   Requires ArcGIS Pro 3.0 or above


### PR DESCRIPTION
Updates the repo to allow a release that includes the work completed to upgrade to support ArcGIS Pro 3.x.

It also removes reference to the usage of Koop for data as spatial views have been added to Arches since this was initially developed.

Closes #151 